### PR TITLE
Fixed two issues with date formatting:

### DIFF
--- a/src/Layout/PatternLayout.vala
+++ b/src/Layout/PatternLayout.vala
@@ -60,12 +60,12 @@ namespace Log4Vala.Layout {
 											pattern_dt.append( pattern[p].to_string() );
 											p++;
 										}
-										p++;
 									} else {
 										pattern_dt.append("%FT%TZ");
 									}
 									pattern_sb.append("s");
 									sb.append( pattern_sb.str.printf( event.timestamp.format( pattern_dt.str ) ) );
+									in_pattern = false;
 									break;
 								case 'm':
 									pattern_sb.append("s");


### PR DESCRIPTION
1) The case body for `'%d'` didn't set `in_pattern = false`, which meant that the `pattern_sb` buffer
had an extra `%s` in it at the start of the next pattern, which in turn meant that that pattern might
be doubled. For example, with the sample format string

`log4vala.appender.LOGFILE.layout.pattern=%d{%Y-%m-%d %H:%M:%S} %5p %c : %m`

I had trace output like:

`2016-03-17 18:56:43TRACETRACE MyApp : My message`

2) Note the lack of a space after the doubled "TRACETRACE". This was due to an extra p++
after we'd processed the date format block; this was swallowing the space in the format pattern that follows the date block.
